### PR TITLE
Add documentation for LCIA methods

### DIFF
--- a/docs/CommonTermAcronyms.md
+++ b/docs/CommonTermAcronyms.md
@@ -17,3 +17,5 @@
 |Data Packages|
 |Dataset|
 |Process|
+|Endpoint Indicator|
+|Midpoint Indicator|

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -93,8 +93,20 @@ You can also search for processes across all repositories via the search functio
  <summary><b>How do I find impact assessment methods?</b></summary>
 
 Impact assessment methods aligned with the Federal Elementary Flow List (FEDEFL) and Federal LCA Commons data are available in two forms:
-- [LCIA Methods without flows](https://www.lcacommons.gov/lcia-methods-without-flows): These JSON-LD files do not contain the flow objects, only the characterization factors. They can be downloaded and imported into any openLCA database. The no flows versions of methods must be imported on top of a database that contains flows, otherwise the methods will not appear in the database.
-- LCIA Methods repositories: Repositories are available for TRACI2.1 and ReCiPe which contain the methods and all relevant flow objects. These repositories are useful for reviewing all characterization factors for flows in the FEDEFL
+- [LCIA Methods without flows](https://www.lcacommons.gov/lcia-methods-without-flows):
+These JSON-LD files do not contain the flow objects, only the characterization factors.
+They can be downloaded and imported into any openLCA database.
+The "No flows" versions of methods must be imported _into_ a database that contains flows, otherwise the methods will not appear in the database.
+Updating a local database with new data which contains new elementary flows (e.g., importing a new process from a repository on the FLCAC) may result in new, uncharacterized flows in the database.
+In these cases, the "No flows" methods should be **re-imported** to enusre that all elementary flows are charcterized.
+
+- LCIA Methods repositories: [Repositories](https://www.lcacommons.gov/lca-collaboration/) are available for TRACI2.1 and ReCiPe which contain the methods and all relevant flow objects.
+These repositories are useful for reviewing all characterization factors for flows in the FEDEFL.
+They can be downloaded and imported into a user's local database.
+However doing so will also import _all_ FEDEFL flows characterized by the method, often resulting in over 100,000 flow objects.
+
+See [Life Cycle Impact Assessment Methods](LCIAmethods.md) for additional details.
+
 </details>
 
 ### Life Cycle Impact Assessment (LCIA)
@@ -102,10 +114,8 @@ Impact assessment methods aligned with the Federal Elementary Flow List (FEDEFL)
 <details>
 
  <summary><b>What LCIA methods are currently harmonized for use with LCI data on the FLCAC?</b></summary>
-The LCIA methods listed in the following table are currently available on the FLCAC and have been harmonized to align with the federal elementary flow list using the [LCIAformatter](https://github.com/USEPA/LCIAformatter)
-<br></br>
-TRACI version 2.2 is currently being harmonized for compatibility with FLCAC data. 
-<br></br>
+
+The LCIA methods listed in the following table are currently available on the FLCAC and have been harmonized to align with the federal elementary flow list using the [LCIAFormatter](https://github.com/USEPA/LCIAformatter).
 
 |LCIA Data|Provider|Link|
 |---|---|---|
@@ -117,8 +127,12 @@ TRACI version 2.2 is currently being harmonized for compatibility with FLCAC dat
 |IPCC GWP|Intergovernmental Panel on Climate Change (IPCC)| |
 |FEDEFL Inventory Methods|US Environmental Protection Agency|[FEDEFL Inventory Methods](https://github.com/USEPA/LCIAformatter/wiki/Inventory-Methods)|
 
-Additional LCIA methods such as CML, Ecopoint, eco-indicator, EDIP2003, EPS, IMAGE 3, LIME, LUCAS, MEEup, ILCD and NAMEA are not currently available in a harmonized format. Flow mapping would be required to use these impact assessment methods with FLCAC data. <br></br>
- 
+TRACI version 2.2 with updated Eutrophication Factors is currently being harmonized for compatibility with FLCAC data. 
+
+Additional LCIA methods such as CML, Ecopoint, eco-indicator, EDIP2003, EPS, IMAGE 3, LIME, LUCAS, MEEup, ILCD and NAMEA are not currently available in a harmonized format. Flow mapping would be required to use these impact assessment methods with FLCAC data.
+
+See [Life Cycle Impact Assessment Methods](LCIAmethods.md) for additional details.
+
 </details>
 <details>
  <summary><b>How do I get impact assessment results (e.g., climate change, eutrophication potential, etc.) for data on the FLCAC?</b></summary>

--- a/docs/LCIAmethods.md
+++ b/docs/LCIAmethods.md
@@ -1,0 +1,42 @@
+# Life Cycle Impact Assessment (LCIA) Methods
+
+A number of LCIA methods have been created for use with the Federal Elementary Flow List (FEDEFL) and the Federal LCA Commons (FLCAC).
+The [LCIA Formatter](https://github.com/USEPA/LCIAformatter) is the primary tool for creating these methods.
+
+> LCIA formatter, or lciafmt, is a Python tool for standardizing the format and flows of life cycle impact assessment (LCIA) data.
+> The tool acquires LCIA data transparently from its original source, cleans the data, shapes them into a standard format using the LCIAmethod format, and optionally applies flow mappings as defined in the FEDEFL.
+
+An article describing the [LCIA Formatter was published in the Jounral of Open Source Software (JOSS)](https://doi.org/10.21105/joss.03392)
+
+## Available Methods
+
+|LCIA Data|Provider|Link|
+|---|---|---|
+|TRACI 2.1|US Environmental Protection Agency|[Tool for Reduction and Assessment of Chemicals and Other Environmental Impacts](https://www.epa.gov/chemical-research/tool-reduction-and-assessment-chemicals-and-other-environmental-impacts-traci)|
+|ReCiPe 2016 Midpoint|National Institute for Public Health and the Environment (The Netherlands)|[LCIA: the ReCiPe Model](https://www.rivm.nl/en/life-cycle-assessment-lca/recipe)|
+|ReCiPe 2016 Endpoint|National Institute for Public Health and the Environment (The Netherlands)|[LCIA: the ReCiPe Model](https://www.rivm.nl/en/life-cycle-assessment-lca/recipe)|
+|ImpactWorld+ Midpoint*|International Reference Center for Life Cycle of Products, Services and Systems (CIRAIG)|[ImpactWorld+](http://www.impactworldplus.org/en/team.php)|
+|ImpactWorld+ Endpoint*|International Reference Center for Life Cycle of Products, Services and Systems (CIRAIG)|[ImpactWorld+](http://www.impactworldplus.org/en/team.php)|
+|IPCC GWP|Intergovernmental Panel on Climate Change (IPCC)| |
+|FEDEFL Inventory Methods|US Environmental Protection Agency|[FEDEFL Inventory Methods](https://github.com/USEPA/LCIAformatter/wiki/Inventory-Methods)|
+
+## Accessing LCIA Methods
+LCIA methods aligned with the FEDEFL are available in two forms.
+Both forms are updated simultaenously, and so results will be the same no matter which version is used.
+- [LCIA Methods without flows](https://www.lcacommons.gov/lcia-methods-without-flows):
+These JSON-LD files do not contain the flow objects, only the characterization factors.
+They can be downloaded and imported into any openLCA database.
+The "No flows" versions of methods must be imported _into_ a database that contains flows, otherwise the methods will not appear in the database.
+Updating a local database with new data which contains new elementary flows (e.g., importing a new process from a repository on the FLCAC) may result in new, uncharacterized flows in the database.
+In these cases, the "No flows" methods should be **re-imported** to enusre that all elementary flows are charcterized.
+
+- LCIA Methods repositories: [Repositories](https://www.lcacommons.gov/lca-collaboration/) are available for TRACI2.1 and ReCiPe which contain the methods and all relevant flow objects.
+These repositories are useful for reviewing all characterization factors for flows in the FEDEFL.
+They can be downloaded and imported into a user's local database.
+However doing so will also import _all_ FEDEFL flows characterized by the method, often resulting in over 100,000 flow objects.
+
+If you require the LCIA data in a different format, please reach out to the Data Curators at FederalLCACommons@erg.com
+
+## Issues and Bugs
+If you identify an error or have questions about specific methods, please use the [Issues](https://github.com/USEPA/LCIAformatter/issues) or [Discussions](https://github.com/USEPA/LCIAformatter/discussions) feature of the LCIA Formatter to report them.
+If you have questions regarding accessing or using the methods in openLCA, please use the [Issues](https://github.com/FLCAC-admin/FLCAC-Curation/issues) or [Discussions](https://github.com/FLCAC-admin/FLCAC-Curation/discussions) feature of the FLCAC Curation repository.

--- a/docs/LCIAmethods.md
+++ b/docs/LCIAmethods.md
@@ -22,11 +22,11 @@ An article describing the [LCIA Formatter was published in the Journal of Open S
 
 ## Accessing LCIA Methods
 LCIA methods aligned with the FEDEFL are available in two forms.
-Both forms are updated simultaneously, and so results will be the same no matter which version is used.
+Both are updated simultaneously, and results will be the same no matter which version is used.
 - [LCIA Methods without flows](https://www.lcacommons.gov/lcia-methods-without-flows):
 These JSON-LD files do not contain the flow objects, only the characterization factors.
 They can be downloaded and imported into any openLCA database.
-The "No flows" versions of methods must be imported _into_ a database that contains flows, otherwise the methods will not appear in the database.
+The "No flows" versions of methods must be imported _into_ a database that contains flows already which they can map to, otherwise the methods will not appear in the database.
 Updating a local database with new data which contains new elementary flows (e.g., importing a new process from a repository on the FLCAC) may result in new, uncharacterized flows in the database.
 In these cases, the "No flows" methods should be **re-imported** to ensure that all elementary flows are characterized.
 

--- a/docs/LCIAmethods.md
+++ b/docs/LCIAmethods.md
@@ -22,7 +22,7 @@ An article describing the [LCIA Formatter was published in the Journal of Open S
 
 ## Accessing LCIA Methods
 LCIA methods aligned with the FEDEFL are available in two forms.
-Both are updated simultaneously, and results will be the same no matter which version is used.
+Both are updated simultaneously, and results will be the same regardless of which version is used.
 - [LCIA Methods without flows](https://www.lcacommons.gov/lcia-methods-without-flows):
 These JSON-LD files do not contain the flow objects, only the characterization factors.
 They can be downloaded and imported into any openLCA database.

--- a/docs/LCIAmethods.md
+++ b/docs/LCIAmethods.md
@@ -15,8 +15,8 @@ An article describing the [LCIA Formatter was published in the Journal of Open S
 |TRACI 2.1|US Environmental Protection Agency|[Tool for Reduction and Assessment of Chemicals and Other Environmental Impacts](https://www.epa.gov/chemical-research/tool-reduction-and-assessment-chemicals-and-other-environmental-impacts-traci)|
 |ReCiPe 2016 Midpoint|National Institute for Public Health and the Environment (The Netherlands)|[LCIA: the ReCiPe Model](https://www.rivm.nl/en/life-cycle-assessment-lca/recipe)|
 |ReCiPe 2016 Endpoint|National Institute for Public Health and the Environment (The Netherlands)|[LCIA: the ReCiPe Model](https://www.rivm.nl/en/life-cycle-assessment-lca/recipe)|
-|ImpactWorld+ Midpoint*|International Reference Center for Life Cycle of Products, Services and Systems (CIRAIG)|[ImpactWorld+](http://www.impactworldplus.org/en/team.php)|
-|ImpactWorld+ Endpoint*|International Reference Center for Life Cycle of Products, Services and Systems (CIRAIG)|[ImpactWorld+](http://www.impactworldplus.org/en/team.php)|
+|ImpactWorld+ Midpoint|International Reference Center for Life Cycle of Products, Services and Systems (CIRAIG)|[ImpactWorld+](http://www.impactworldplus.org/en/team.php)|
+|ImpactWorld+ Endpoint|International Reference Center for Life Cycle of Products, Services and Systems (CIRAIG)|[ImpactWorld+](http://www.impactworldplus.org/en/team.php)|
 |IPCC GWP|Intergovernmental Panel on Climate Change (IPCC)| |
 |FEDEFL Inventory Methods|US Environmental Protection Agency|[FEDEFL Inventory Methods](https://github.com/USEPA/LCIAformatter/wiki/Inventory-Methods)|
 
@@ -28,7 +28,8 @@ These JSON-LD files do not contain the flows, only the characterization factors.
 They can be downloaded and imported into any openLCA database.
 The "No flows" versions of methods must be imported _into_ a database that contains the relevant flows already, otherwise the methods will not calculate correctly.
 Updating a local database with new data which contains new elementary flows (e.g., importing a new process from a repository on the FLCAC) may result in new, uncharacterized flows in the database.
-In these cases, the "No flows" methods should be **re-imported** to ensure that all elementary flows are characterized. Using the "No flows" version of an LCIA method allows the practitioner to limit the number of elementary flows in their project database, simplifying LCIA flow checks.
+In these cases, the "No flows" methods should be **re-imported** to ensure that all elementary flows are characterized.
+Using the "No flows" version of an LCIA method allows the practitioner to limit the number of elementary flows in their project database, simplifying LCIA flow checks.
 
 - LCIA Methods repositories: [Repositories](https://www.lcacommons.gov/lca-collaboration/) are available for TRACI2.1 and ReCiPe which contain the methods and all relevant flow objects.
 These repositories are useful for reviewing all characterization factors for flows in the FEDEFL.

--- a/docs/LCIAmethods.md
+++ b/docs/LCIAmethods.md
@@ -28,7 +28,7 @@ These JSON-LD files do not contain the flow objects, only the characterization f
 They can be downloaded and imported into any openLCA database.
 The "No flows" versions of methods must be imported _into_ a database that contains flows already which they can map to, otherwise the methods will not appear in the database.
 Updating a local database with new data which contains new elementary flows (e.g., importing a new process from a repository on the FLCAC) may result in new, uncharacterized flows in the database.
-In these cases, the "No flows" methods should be **re-imported** to ensure that all elementary flows are characterized.
+In these cases, the "No flows" methods should be **re-imported** to ensure that all elementary flows are characterized. Using the "No flows" version of an LCIA method allows the practitioner to limit the number of elementary flows in their project database, simplifying LCIA flow checks.
 
 - LCIA Methods repositories: [Repositories](https://www.lcacommons.gov/lca-collaboration/) are available for TRACI2.1 and ReCiPe which contain the methods and all relevant flow objects.
 These repositories are useful for reviewing all characterization factors for flows in the FEDEFL.

--- a/docs/LCIAmethods.md
+++ b/docs/LCIAmethods.md
@@ -6,7 +6,7 @@ The [LCIA Formatter](https://github.com/USEPA/LCIAformatter) is the primary tool
 > LCIA formatter, or lciafmt, is a Python tool for standardizing the format and flows of life cycle impact assessment (LCIA) data.
 > The tool acquires LCIA data transparently from its original source, cleans the data, shapes them into a standard format using the LCIAmethod format, and optionally applies flow mappings as defined in the FEDEFL.
 
-An article describing the [LCIA Formatter was published in the Jounral of Open Source Software (JOSS)](https://doi.org/10.21105/joss.03392)
+An article describing the [LCIA Formatter was published in the Journal of Open Source Software (JOSS)](https://doi.org/10.21105/joss.03392)
 
 ## Available Methods
 
@@ -22,13 +22,13 @@ An article describing the [LCIA Formatter was published in the Jounral of Open S
 
 ## Accessing LCIA Methods
 LCIA methods aligned with the FEDEFL are available in two forms.
-Both forms are updated simultaenously, and so results will be the same no matter which version is used.
+Both forms are updated simultaneously, and so results will be the same no matter which version is used.
 - [LCIA Methods without flows](https://www.lcacommons.gov/lcia-methods-without-flows):
 These JSON-LD files do not contain the flow objects, only the characterization factors.
 They can be downloaded and imported into any openLCA database.
 The "No flows" versions of methods must be imported _into_ a database that contains flows, otherwise the methods will not appear in the database.
 Updating a local database with new data which contains new elementary flows (e.g., importing a new process from a repository on the FLCAC) may result in new, uncharacterized flows in the database.
-In these cases, the "No flows" methods should be **re-imported** to enusre that all elementary flows are charcterized.
+In these cases, the "No flows" methods should be **re-imported** to ensure that all elementary flows are characterized.
 
 - LCIA Methods repositories: [Repositories](https://www.lcacommons.gov/lca-collaboration/) are available for TRACI2.1 and ReCiPe which contain the methods and all relevant flow objects.
 These repositories are useful for reviewing all characterization factors for flows in the FEDEFL.

--- a/docs/LCIAmethods.md
+++ b/docs/LCIAmethods.md
@@ -24,9 +24,9 @@ An article describing the [LCIA Formatter was published in the Journal of Open S
 LCIA methods aligned with the FEDEFL are available in two forms.
 Both are updated simultaneously, and results will be the same regardless of which version is used.
 - [LCIA Methods without flows](https://www.lcacommons.gov/lcia-methods-without-flows):
-These JSON-LD files do not contain the flow objects, only the characterization factors.
+These JSON-LD files do not contain the flows, only the characterization factors.
 They can be downloaded and imported into any openLCA database.
-The "No flows" versions of methods must be imported _into_ a database that contains flows already which they can map to, otherwise the methods will not appear in the database.
+The "No flows" versions of methods must be imported _into_ a database that contains the relevant flows already, otherwise the methods will not calculate correctly.
 Updating a local database with new data which contains new elementary flows (e.g., importing a new process from a repository on the FLCAC) may result in new, uncharacterized flows in the database.
 In these cases, the "No flows" methods should be **re-imported** to ensure that all elementary flows are characterized. Using the "No flows" version of an LCIA method allows the practitioner to limit the number of elementary flows in their project database, simplifying LCIA flow checks.
 

--- a/docs/SOPs/1-updating_fedefl.md
+++ b/docs/SOPs/1-updating_fedefl.md
@@ -2,7 +2,8 @@
 
 ## Purpose
 
-This SOP documents procedures for making changes to the Federal Elementary Flow List (FEDEFL) data objects on the Federal LCA Commons (FLCAC).
+This SOP documents procedures for making changes to the Federal Elementary Flow List (FEDEFL) data objects on the Federal LCA Commons (FLCAC). 
+The FEDEFL needs to be updated when changes are made to flows, contexts, or metadata within.
 
 ## Procedure
 

--- a/docs/SOPs/1-updating_fedefl.md
+++ b/docs/SOPs/1-updating_fedefl.md
@@ -1,0 +1,17 @@
+# Updating the Federal Elementary Flow List
+
+## Purpose
+
+This SOP documents procedures for making changes to the Federal Elementary Flow List (FEDEFL) data objects on the Federal LCA Commons (FLCAC).
+
+## Procedure
+
+1. Any changes to the FEDEFL must align with a fedelemflowlist package release and update to the list version.
+Fedelemflowlist release notes will indicate any changes to the flow list (via additions or deletions).
+
+2. Upon package release, the FEDEFL is added to the [EPA Data Commons](https://dmap-data-commons-ord.s3.amazonaws.com/index.html?prefix=#fedelemflowlist/) in parquet and JSON-LD formats.
+
+3. The FEDEFL is updated on the Federal LCA Commons Elementary Flow List repository:
+Import the JSON-LD file into the repository and select "Overwrite all exisiting data sets".
+If any flows need to be removed, delete them manually.
+

--- a/docs/SOPs/1-updating_fedefl.md
+++ b/docs/SOPs/1-updating_fedefl.md
@@ -4,6 +4,7 @@
 
 This SOP documents procedures for making changes to the Federal Elementary Flow List (FEDEFL) data objects on the Federal LCA Commons (FLCAC). 
 The FEDEFL needs to be updated when changes are made to flows, contexts, or metadata within.
+This SOP is inteded for use by the Data Curators.
 
 ## Procedure
 
@@ -14,5 +15,5 @@ Fedelemflowlist release notes will indicate any changes to the flow list (via ad
 
 3. The FEDEFL is updated on the Federal LCA Commons Elementary Flow List repository:
 Import the JSON-LD file into the repository and select "Overwrite all exisiting data sets".
-If any flows need to be removed, delete them manually.
+If any flows need to be removed (i.e., those identified in the change log), delete them manually.
 

--- a/docs/SOPs/2-updating_lcia.md
+++ b/docs/SOPs/2-updating_lcia.md
@@ -1,0 +1,25 @@
+# Updating Life Cycle Impact Assessment Methods using LCIA Formatter
+
+## Purpose
+
+This SOP documents procedures for making updates or adding new LCIA methods to the Federal LCA Commons (FLCAC).
+
+## Procedure
+
+1. Any changes to an LCIA Method must align with a lciafmt package release and update to the package version.
+LCIA Formatter release notes will indicate changes to characterization factors for all methods.
+
+2. Upon package release, revised methods are added to the [EPA Data Commons](https://dmap-data-commons-ord.s3.amazonaws.com/index.html?prefix=#lciafmt/) in parquet format.
+
+3. The LCIA methods are updated on the Federal LCA Commons in the appropriate repository (if applicable):
+Generate with the LCIA Formatter a JSON-LD version of the method _with_ all flows.
+Import that JSON-LD file into the repository and select "Overwrite all exisiting data sets" to update both the LCIA method and the underlying elementary flows.
+Confirm that no uncharacterized flows remain (e.g., due to a change in mapping).
+If any remain, remove them from the repository.
+
+4. The LCIA methods are added as JSON-LD to lcacommons.gov ["No-flows" LCIA Method page](https://www.lcacommons.gov/lcia-methods-without-flows):
+Generate with the LCIA Formatter a JSON-LD version of the method _without_ flows.
+Create a new entry in the USDA Ag Data Commons.
+Once approved, the entry will be added to Data.gov.
+Add links to the No-flows page, and move the prior version to the archive section of the page.
+

--- a/docs/SOPs/2-updating_lcia.md
+++ b/docs/SOPs/2-updating_lcia.md
@@ -3,6 +3,7 @@
 ## Purpose
 
 This SOP documents procedures for making updates or adding new LCIA methods to the Federal LCA Commons (FLCAC).
+This SOP is inteded for use by the Data Curators.
 
 ## Procedure
 


### PR DESCRIPTION
Adds SOP for updating the FEDEFL and LCIA methods. Includes public facing documentation for use/access of LCIA methods.

I am recommending the following slightly modified text for the [No Flows](https://www.lcacommons.gov/lcia-methods-without-flows) page:

> This is a collection of life cycle impact assessment datasets in JSON-LD (zip) format following the openLCA schema. These datasets are appropriate for import into an existing openLCA database (v2) that is already populated with complete LCI data and elementary flows belonging to the Federal Elementary Flow List (FEDEFL). Import of these datasets will add LCIA methods and categories with characterization factors for all FEDEFL flows currently in the database. For additional details on their use, see [LCIA Methods](https://github.com/FLCAC-admin/FLCAC-Curation/blob/main/docs/LCIAmethods.md).